### PR TITLE
Fixed library name on OSX

### DIFF
--- a/glfw.nimble
+++ b/glfw.nimble
@@ -1,7 +1,7 @@
 # Package
 
 packageName   = "glfw"
-version       = "3.2.0"
+version       = "3.2.1"
 author        = "Rafael Vasco, Cory Null(Noll) Crimmins - Golden"
 description   = "Nimrod bindings for GLFW3 library"
 license       = "MIT"

--- a/glfw3.nim
+++ b/glfw3.nim
@@ -7,7 +7,7 @@
 when defined(windows):
     const GlfwLib = "glfw3.dll"
 elif defined(macosx):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/Cocoa.nim
+++ b/glfw3native/Cocoa.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/EGL.nim
+++ b/glfw3native/EGL.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/GLX.nim
+++ b/glfw3native/GLX.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/Mir.nim
+++ b/glfw3native/Mir.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/NSGL.nim
+++ b/glfw3native/NSGL.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/WGL.nim
+++ b/glfw3native/WGL.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/Wayland.nim
+++ b/glfw3native/Wayland.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/Win32.nim
+++ b/glfw3native/Win32.nim
@@ -7,7 +7,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 

--- a/glfw3native/X11.nim
+++ b/glfw3native/X11.nim
@@ -6,7 +6,7 @@ import glfw3
 when defined(Windows):
     const GlfwLib = "glfw3.dll"
 elif defined(MacOSX):
-    const GlfwLib = "libglfw3.dylib"
+    const GlfwLib = "libglfw.3.dylib"
 else:
     const GlfwLib = "libglfw.so.3"
 


### PR DESCRIPTION
I needed this library for a project I'm working on with OSX 10.12.5 
The library is great 👍 but the dylib had the wrong name.

Just FYI:
There are also some nimble warnings about "glfw3.nim" needing to be renamed to "glfw.nim" for namespace reasons. I ignored them, but I thought you might want to know.

```
$ nimble install
   Warning: File inside package 'glfw' is outside of permitted namespace, should be named 'glfw.nim' but was named 'glfw3.nim' instead. This will be an error in the future.
      Hint: Rename this file to 'glfw.nim', move it into a 'glfw/' subdirectory, or prevent its installation by adding `skipFiles = @["glfw3.nim"]` to the .nimble file. See https://github.com/nim-lang/nimble#libraries for more info.
  Verifying dependencies for glfw@3.2.1
 Installing glfw@3.2.1
   Success: glfw installed successfully.
```