### PR TITLE
Make nimble content and reduce installation size

### DIFF
--- a/glfw.nimble
+++ b/glfw.nimble
@@ -6,6 +6,8 @@ author        = "Rafael Vasco, Cory Null(Noll) Crimmins - Golden"
 description   = "Nimrod bindings for GLFW3 library"
 license       = "MIT"
 
+skipDirs = @["test"]
+
 when defined(Windows):
   switch("GLFW_EXPOSE_NATIVE_WIN32")
   switch("GLFW_EXPOSE_NATIVE_WGL")


### PR DESCRIPTION
Adds the "test" directory to skipDirs, making nimble skip its installation and stop complaining about it.